### PR TITLE
/admin/settings/players can break if a previously registered player is removed from registration.

### DIFF
--- a/mediacore/model/players.py
+++ b/mediacore/model/players.py
@@ -91,7 +91,10 @@ class PlayerPrefs(object):
         :rtype: unicode
         :returns: A i18n-ready string name.
         """
-        return self.player_cls.display_name
+        try:
+            return self.player_cls.display_name
+        except AttributeError:
+            return '(unregistered %s)' % self.name
 
     @property
     @memoize


### PR DESCRIPTION
this patch shows its class name (since the description is not available anymore) and the admin can remove the player from DB with the X button.
