### PR TITLE
Prevent mediacore from attempting to save values of form fields that have been disabled

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,3 +1,7 @@
+SSIS DragonTV - Streaming video for K-12 schools:
+  * Expanded unauthenticated upload features (validation of specific domains, creation of limited "student" accounts)
+  * General user interface adjustments / improvements
+
 MediaCore Community Edition - A video, audio, and podcast publication platform.
 http://mediacorecommunity.org/
 


### PR DESCRIPTION
Although this bug doesn't crop up unless disabled=True is passed when creating a form widget, this is probably what we want in case in future we have permissions where users cannot edit certain fields.
