### PR TITLE
Prevent mediacore from saving values of forms that have been disabled

### DIFF
--- a/mediacore/lib/base.py
+++ b/mediacore/lib/base.py
@@ -306,6 +306,9 @@ class BaseSettingsController(BaseController):
         """Take a nested dict and return a flat dict of setting values."""
         setting_values = {}
         for field in form.c:
+            if field.disabled:
+                # can safely ignore values of disabled fields
+                continue
             if isinstance(field, _ContainerMixin):
                 setting_values.update(self._flatten_settings_from_form(
                     settings, field, form_values[field._name]


### PR DESCRIPTION
Although this bug doesn't crop up unless disabled=True is sent while making form widgets, when you did so you get unpredictable results during save. If users are ever given different permissions to modify or not modify fields, this would become an issue.
