### PR TITLE
Updated mac install doc

### DIFF
--- a/doc/install/mac-os.rst
+++ b/doc/install/mac-os.rst
@@ -101,7 +101,7 @@ with the following command:
 
 .. sourcecode:: bash
 
-    virtualenv.py --no-site-packages --python="$pathtobrewpython" /path/to/virtual_environment
+    virtualenv --no-site-packages --python="$brewpython"/python /path/to/virtual_environment
 
 Finally, we can activate this virutal environment, which we'll have to do when we're
 working with mediacore, with the following command:


### PR DESCRIPTION
Which cc instead of gcc, and instead of manipulating path we just use the full path name, which we save into a variable.
