### PR TITLE
Add setup_requires so paster_plugins are available during setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
         ],
 
     install_requires=install_requires,
+    setup_requires=install_requires,
     paster_plugins=[
         'PasteScript',
         'Pylons',


### PR DESCRIPTION
python setup.py develop fails because paster_plugins are not registered along with some of the other setup plugins. Anything required during setup should be in setup_requires.
