### PR TITLE
Remove mysql as dependency

### DIFF
--- a/doc/install/index.rst
+++ b/doc/install/index.rst
@@ -141,7 +141,41 @@ you install will only be accessible when you've activated the environment.
 virtual environment as we just did in the line above.**
 
 
-Step 2: Install MediaDrop
+Step 2: Install database drivers
+================================
+
+MediaDrop uses `SQLAlchemy <http://www.sqlalchemy.org/>` in order to access
+the database server, so you need yo install a database driver in order to
+access your favourite database. The following lines will descrive how two
+install a database driver for the most used databases:
+
+
+a. MySQL:
+
+.. sourcecode:: bash
+
+   pip install mysql-python
+
+or
+
+.. sourcecode:: bash
+
+   easy_install mysql-python
+
+b. PostgreSQL:
+
+.. sourcecode:: bash
+
+   pip install psycopg2
+
+or
+
+.. sourcecode:: bash
+
+   easy_install psycopg2
+
+
+Step 3: Install MediaDrop
 ============================
 
 There are two main ways to get MediaDrop:
@@ -183,7 +217,7 @@ b. **For developers and power users** we recommend using the source code
       cd ..
 
 
-Step 3: Basic Configuration File
+Step 4: Basic Configuration File
 ================================
 
 Next we generate a configuration file named ``deployment.ini`` which contains
@@ -212,6 +246,13 @@ password, and database name. For example:
 
    sqlalchemy.url = mysql://mediadrop_user:mysecretpassword@localhost/mediadrop?charset=utf8&use_unicode=0
 
+If you use PostgreSQL you must change the driver and remove the connection
+parameters defined by default. So the resulting url might look like:
+
+.. sourcecode:: ini
+
+   sqlalchemy.url = postgresql://mediadrop_user:mysecretpassword@localhost/mediadrop
+
 
 Developers should also set ``debug = true`` in the config file but be aware that
 this is a security risk in a publicly accessible deployment. 
@@ -219,7 +260,7 @@ Also ``db.check_for_leaked_connections = True`` (in ``[app:main]``) might give
 you important warnings on the console.
 
 
-Step 4: Load Initial Data
+Step 5: Load Initial Data
 =============================
 
 First we need to set up the directory which contains all the file content. Copy
@@ -258,7 +299,7 @@ In a future release, we plan to release optional plugins to use
 a database-independent search engine.
 
 
-Step 5: Launch the Built-in Server
+Step 6: Launch the Built-in Server
 ==================================
 
 Now that MediaDrop itself is installed and the basics are configured,
@@ -283,7 +324,7 @@ If this is your development machine, you're good to go.
 
 .. _production_deployments:
 
-Step 6: Production Deployments
+Step 7: Production Deployments
 ==============================
 
 MediaDrop is WSGI-based so there are many possible ways to deploy it.

--- a/doc/install/quick-overview.rst
+++ b/doc/install/quick-overview.rst
@@ -20,6 +20,8 @@ If you're not already familiar with the process, head to the main
 #. For production, run ``paster make-config mediacore deployment.ini``
    and to create a unique ``deployment.ini`` config. On development
    machines there's already a ``development.ini`` file for you to use.
+#. Install your prefered database drivers. We recommend using MySQL or
+   PostgreSQL for production servers. Development environments can run sqlite.
 #. Configure your database credentials in the ini config file.
 #. Run ``paster setup-app path/to/your/config.ini`` to set up the database
    tables and data.

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ Paste >= 1.7.5.1 # (version required by Pylons 1.0)
 PasteDeploy >= 1.5 # (version required by Pylons 1.0)
 ToscaWidgets >= 0.9.12 # 0.9.9 is not compatible with Pylons 1.0
 tw.forms == 0.9.9
-MySQL-python >= 1.2.2
 BeautifulSoup == 3.0.7a
 # We monkeypatch this version of BeautifulSoup in mediadrop.__init__
 # Patch pending: https://bugs.launchpad.net/beautifulsoup/+bug/397997

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ install_requires = setup_requires + [
     'PasteDeploy >= 1.5',  # (version required by Pylons 1.0)
     'ToscaWidgets >= 0.9.12', # 0.9.9 is not compatible with Pylons 1.0
     'tw.forms == 0.9.9',
-    'MySQL-python >= 1.2.2',
     'BeautifulSoup == 3.0.7a',
         # We monkeypatch this version of BeautifulSoup in mediadrop.__init__
         # Patch pending: https://bugs.launchpad.net/beautifulsoup/+bug/397997


### PR DESCRIPTION
As we prefer to use PostgreSQL instead of MySQL, we won't need the mysql-database drivers to setup mediadrop. So I propose the following changes:
- Remove mysql-python from setup.py and requirements 
- Update the docs to reflect how to setup it on MySQL and on PostrgeSQL. 

This PR implements it. 
