### PR TITLE
Cleaning allow rel nofollow

### DIFF
--- a/mediadrop/lib/tests/xhtml_normalization_test.py
+++ b/mediadrop/lib/tests/xhtml_normalization_test.py
@@ -7,6 +7,7 @@
 # See LICENSE.txt in the main project directory, for more information.
 
 from mediadrop.lib.helpers import clean_xhtml, line_break_xhtml
+from mediadrop.lib.xhtml import cleaner_settings
 from mediadrop.lib.test.pythonic_testcase import *
 
 
@@ -47,6 +48,14 @@ class XHTMLNormalizationTest(PythonicTestCase):
         original = 'http://example.com'
         cleaned = clean_xhtml(original)
         assert_equals(cleaned, '<a href="http://example.com" rel="nofollow">http://example.com</a>')
+
+    def test_adds_target_blank_to_links(self):
+        original = '<a href="http://example.com">link</a>'
+        from copy import deepcopy
+        settings = deepcopy(cleaner_settings)
+        settings['filters'].append('add_target_blank')
+        cleaned = clean_xhtml(original, _cleaner_settings=settings)
+        assert_equals(cleaned, '<a href="http://example.com" rel="nofollow" target="_blank">link</a>')
 
 import unittest
 def suite():


### PR DESCRIPTION
See commit messages:

> Bugfix: XHTML Sanitizer did not add nofollow attribute to links
> While the filter actually did add the attribute, the tag attribute
> filter removed it afterwards. Now it does not and we have a test.
> 
> Feature: Add 'add_target_blank' filter to Cleaner
> Currently, it is not used anyhwere but can be added to cleaner settings
> by plugins. Possibly a good default for the description?
