### PR TITLE
Replace Domain in File Headers and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MediaDrop
 MediaDrop is a modular video, audio, and podcast publication platform which can
 be extended with plugins (previously known as "MediaCore Community Edition").
 
-The offical website is [http://mediadrop.video](http://mediadrop.net/) contains
+The offical website is [http://mediadrop.video](http://mediadrop.video/) contains
 more information about the software including
 [installation documentation](http://mediadrop.video/docs/install/).
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ MediaDrop
 MediaDrop is a modular video, audio, and podcast publication platform which can
 be extended with plugins (previously known as "MediaCore Community Edition").
 
-The offical website is [http://mediadrop.net](http://mediadrop.net/) contains
+The offical website is [http://mediadrop.video](http://mediadrop.net/) contains
 more information about the software including
-[installation documentation](http://mediadrop.net/docs/install/).
+[installation documentation](http://mediadrop.video/docs/install/).
 
 If you require help with MediaDrop customization or installation, check out our
-friendly [community forums](http://mediadrop.net/community).
+friendly [community forums](http://mediadrop.video/community).
 
 

--- a/batch-scripts/upgrade/upgrade_from_v09_preserve_facebook_xid_comments.py
+++ b/batch-scripts/upgrade/upgrade_from_v09_preserve_facebook_xid_comments.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/deployment-scripts/mod_fastcgi/.htaccess
+++ b/deployment-scripts/mod_fastcgi/.htaccess
@@ -1,5 +1,5 @@
 # .htaccess file for installation of MediaDrop with Apache/FastCGI
-# See installation instructions at http://mediadrop.net/docs/install/apache-fastcgi.html
+# See installation instructions at http://mediadrop.video/docs/install/apache-fastcgi.html
 
 <IfModule mod_fcgid.c>
     AddHandler fcgid-script .fcgi

--- a/development.ini
+++ b/development.ini
@@ -60,7 +60,7 @@ sa_auth.cookie_secret = superdupersecret
 #                    block with an alias from the path __mediacore_serve__ to
 #                    your /path/to/data/media directory.
 #                    See the full docs below for an example:
-#                    http://mediadrop.net/docs/install/nginx-uwsgi.html
+#                    http://mediadrop.video/docs/install/nginx-uwsgi.html
 #   default - uses environ['wsgi.file_wrapper'] if it's provided by the server,
 #             otherwise a pure-python file iterator returns the file in chunks
 file_serve_method = default

--- a/doc/dev/contributing.rst
+++ b/doc/dev/contributing.rst
@@ -13,7 +13,7 @@ them!
 Please post issues to our `issue tracker on Github
 <https://github.com/mediadrop/mediadrop/issues>`_.
 
-You can always post to our `community forums <http://mediadrop.net/community/>`_ if you aren't sure if its a bug or
+You can always post to our `community forums <http://mediadrop.video/community/>`_ if you aren't sure if its a bug or
 not.
 
 

--- a/doc/install/index.rst
+++ b/doc/install/index.rst
@@ -146,7 +146,7 @@ Step 2: Install MediaDrop
 
 There are two main ways to get MediaDrop:
 
-a. You can `download the latest official release of MediaDrop <http://mediadrop.net/download>`_ from our site.
+a. You can `download the latest official release of MediaDrop <http://mediadrop.video/download>`_ from our site.
 
    Once you've downloaded MediaDrop, it's time to unpack it and install.
 
@@ -276,7 +276,7 @@ admin**. (Remember to `change your password
 
 If this produces errors then MediaDrop or one of its dependencies is not
 setup correctly. Please feel free to ask questions and submit solutions
-via our `community forums <http://mediadrop.net/community/>`_.
+via our `community forums <http://mediadrop.video/community/>`_.
 
 If this is your development machine, you're good to go.
 

--- a/doc/install/upgrade.rst
+++ b/doc/install/upgrade.rst
@@ -71,14 +71,14 @@ before creating the new virtualenv).
 Step 2: Install the new MediaDrop Files
 ------------------------------------------
 
-`Download the latest official release of MediaDrop <http://mediadrop.net/download>`_ 
+`Download the latest official release of MediaDrop <http://mediadrop.video/download>`_ 
 from our site, then unpack it beside your current MediaDrop installation.
 
 .. sourcecode:: bash
 
    # Download the latest distribution beside the current installation
    cd /path/to/mediadrop-old/..
-   wget http://static.mediadrop.net/releases/mediadrop-new.tar.gz
+   wget http://static.mediadrop.video/releases/mediadrop-new.tar.gz
 
    # Unpack the downloaded distribution
    tar xzvf mediadrop-new.tar.gz

--- a/doc/user/admin/media.rst
+++ b/doc/user/admin/media.rst
@@ -5,7 +5,7 @@ Media Management Admin Interface
 ================================
 
 A good first resource for media management is the
-`MediaCore CE Workflow Video <http://static.mediadrop.net/files/videos/tutorial-workflow-in-mediacore.mp4>`_.
+`MediaCore CE Workflow Video <http://static.mediadrop.video/files/videos/tutorial-workflow-in-mediacore.mp4>`_.
 
 
 Files

--- a/doc/user/admin/podcasts.rst
+++ b/doc/user/admin/podcasts.rst
@@ -5,5 +5,5 @@ Podcast Management Admin Interface
 ==================================
 
 A good first resource to get started with managing podcasts is the
-`Creating a Podcast in MediaCore CE video <http://static.mediadrop.net/files/videos/tutorial-create-podcast-in-mediacore.mp4>`_.
+`Creating a Podcast in MediaCore CE video <http://static.mediadrop.video/files/videos/tutorial-create-podcast-in-mediacore.mp4>`_.
 

--- a/mediadrop/__init__.py
+++ b/mediadrop/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or
@@ -13,8 +13,8 @@ __version__ = '0.11dev'
 __status__ = 'Beta'
 __copyright__ = 'Copyright 2009-2014, MediaDrop contributors'
 __license__ = 'GPLv3'
-__email__ = 'info@mediadrop.net'
-__maintainer__ = 'http://mediadrop.net'
+__email__ = 'info@mediadrop.video'
+__maintainer__ = 'http://mediadrop.video'
 __all__ = ['__version__', 'debug', 'ipython']
 
 USER_AGENT = 'MediaDrop/%s' % __version__

--- a/mediadrop/config/deployment.ini_tmpl
+++ b/mediadrop/config/deployment.ini_tmpl
@@ -56,7 +56,7 @@ sa_auth.cookie_secret = ${app_instance_secret}
 #                    block with an alias from the path __mediadrop_serve__ to
 #                    your /path/to/mediadrop/data/media directory.
 #                    See the full docs below for an example:
-#                    http://mediadrop.net/docs/install/nginx-uwsgi.html
+#                    http://mediadrop.video/docs/install/nginx-uwsgi.html
 #   default - uses environ['wsgi.file_wrapper'] if it's provided by the server,
 #             otherwise a pure-python file iterator returns the file in chunks
 file_serve_method = default

--- a/mediadrop/config/environment.py
+++ b/mediadrop/config/environment.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/config/middleware.py
+++ b/mediadrop/config/middleware.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/config/routing.py
+++ b/mediadrop/config/routing.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/admin/categories.py
+++ b/mediadrop/controllers/admin/categories.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/admin/comments.py
+++ b/mediadrop/controllers/admin/comments.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/admin/groups.py
+++ b/mediadrop/controllers/admin/groups.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/admin/index.py
+++ b/mediadrop/controllers/admin/index.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/admin/media.py
+++ b/mediadrop/controllers/admin/media.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/admin/players.py
+++ b/mediadrop/controllers/admin/players.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/admin/podcasts.py
+++ b/mediadrop/controllers/admin/podcasts.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/admin/settings.py
+++ b/mediadrop/controllers/admin/settings.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/admin/storage.py
+++ b/mediadrop/controllers/admin/storage.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/admin/tags.py
+++ b/mediadrop/controllers/admin/tags.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/admin/users.py
+++ b/mediadrop/controllers/admin/users.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/api/__init__.py
+++ b/mediadrop/controllers/api/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/api/categories.py
+++ b/mediadrop/controllers/api/categories.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/api/media.py
+++ b/mediadrop/controllers/api/media.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or
@@ -454,25 +454,25 @@ class MediaController(BaseController):
                     scheme (unicode)
                         The
                         :attr:`scheme <mediadrop.lib.uri.StorageUri.scheme>`
-                        (e.g. 'http' in the URI 'http://mediadrop.net/docs/',
-                        'rtmp' in the URI 'rtmp://mediadrop.net/docs/', or
+                        (e.g. 'http' in the URI 'http://mediadrop.video/docs/',
+                        'rtmp' in the URI 'rtmp://mediadrop.video/docs/', or
                         'file' in the URI 'file:///some/local/file.mp4')
                     server (unicode)
                         The
                         :attr:`server name <mediadrop.lib.uri.StorageUri.server_uri>`
-                        (e.g. 'mediadrop.net' in the URI
-                        'http://mediadrop.net/docs')
+                        (e.g. 'mediadrop.video' in the URI
+                        'http://mediadrop.video/docs')
                     file (unicode)
                         The
                         :attr:`file path <mediadrop.lib.uri.StorageUri.file_uri>`
                         part of the URI.  (e.g. 'docs' in the URI
-                        'http://mediadrop.net/docs')
+                        'http://mediadrop.video/docs')
                     uri (unicode)
                         The full URI string (minus scheme) built from the
                         server_uri and file_uri.
                         See :attr:`mediadrop.lib.uri.StorageUri.__str__`.
-                        (e.g. 'mediadrop.net/docs' in the URI
-                        'http://mediadrop.net/docs')
+                        (e.g. 'mediadrop.video/docs' in the URI
+                        'http://mediadrop.video/docs')
 
         """
         uris = []

--- a/mediadrop/controllers/api/tests/authentication_test.py
+++ b/mediadrop/controllers/api/tests/authentication_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2014 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/categories.py
+++ b/mediadrop/controllers/categories.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/errors.py
+++ b/mediadrop/controllers/errors.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/login.py
+++ b/mediadrop/controllers/login.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/media.py
+++ b/mediadrop/controllers/media.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/podcasts.py
+++ b/mediadrop/controllers/podcasts.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/sitemaps.py
+++ b/mediadrop/controllers/sitemaps.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/tests/login_test.py
+++ b/mediadrop/controllers/tests/login_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/tests/upload_test.py
+++ b/mediadrop/controllers/tests/upload_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/controllers/upload.py
+++ b/mediadrop/controllers/upload.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/__init__.py
+++ b/mediadrop/forms/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/__init__.py
+++ b/mediadrop/forms/admin/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/categories.py
+++ b/mediadrop/forms/admin/categories.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/comments.py
+++ b/mediadrop/forms/admin/comments.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/groups.py
+++ b/mediadrop/forms/admin/groups.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/media.py
+++ b/mediadrop/forms/admin/media.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/players.py
+++ b/mediadrop/forms/admin/players.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/podcasts.py
+++ b/mediadrop/forms/admin/podcasts.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/settings.py
+++ b/mediadrop/forms/admin/settings.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/storage/__init__.py
+++ b/mediadrop/forms/admin/storage/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/storage/ftp.py
+++ b/mediadrop/forms/admin/storage/ftp.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/storage/localfiles.py
+++ b/mediadrop/forms/admin/storage/localfiles.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/storage/remoteurls.py
+++ b/mediadrop/forms/admin/storage/remoteurls.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/tags.py
+++ b/mediadrop/forms/admin/tags.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/admin/users.py
+++ b/mediadrop/forms/admin/users.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/comments.py
+++ b/mediadrop/forms/comments.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/login.py
+++ b/mediadrop/forms/login.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/forms/uploader.py
+++ b/mediadrop/forms/uploader.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/app_globals.py
+++ b/mediadrop/lib/app_globals.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/auth/api.py
+++ b/mediadrop/lib/auth/api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/auth/group_based_policy.py
+++ b/mediadrop/lib/auth/group_based_policy.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/auth/middleware.py
+++ b/mediadrop/lib/auth/middleware.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/auth/permission_system.py
+++ b/mediadrop/lib/auth/permission_system.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/auth/pylons_glue.py
+++ b/mediadrop/lib/auth/pylons_glue.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/auth/query_result_proxy.py
+++ b/mediadrop/lib/auth/query_result_proxy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/auth/tests/cookieplugin_test.py
+++ b/mediadrop/lib/auth/tests/cookieplugin_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/auth/tests/filtering_restricted_items_test.py
+++ b/mediadrop/lib/auth/tests/filtering_restricted_items_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/auth/tests/group_based_permissions_policy_test.py
+++ b/mediadrop/lib/auth/tests/group_based_permissions_policy_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/auth/tests/is_logged_in_decorator_test.py
+++ b/mediadrop/lib/auth/tests/is_logged_in_decorator_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/auth/tests/loginform_test.py
+++ b/mediadrop/lib/auth/tests/loginform_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/auth/tests/mediadrop_permission_system_test.py
+++ b/mediadrop/lib/auth/tests/mediadrop_permission_system_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/auth/tests/permission_system_test.py
+++ b/mediadrop/lib/auth/tests/permission_system_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/auth/tests/query_result_proxy_test.py
+++ b/mediadrop/lib/auth/tests/query_result_proxy_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/auth/tests/static_query_test.py
+++ b/mediadrop/lib/auth/tests/static_query_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/auth/util.py
+++ b/mediadrop/lib/auth/util.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/base.py
+++ b/mediadrop/lib/base.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/cli/__init__.py
+++ b/mediadrop/lib/cli/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/cli/util.py
+++ b/mediadrop/lib/cli/util.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/cli_commands.py
+++ b/mediadrop/lib/cli_commands.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/compat/__init__.py
+++ b/mediadrop/lib/compat/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/css_delivery.py
+++ b/mediadrop/lib/css_delivery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/decorators.py
+++ b/mediadrop/lib/decorators.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/email.py
+++ b/mediadrop/lib/email.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/filesize.py
+++ b/mediadrop/lib/filesize.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2014 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is is dual licensed under the MIT license or

--- a/mediadrop/lib/filetypes.py
+++ b/mediadrop/lib/filetypes.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/helpers.py
+++ b/mediadrop/lib/helpers.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or
@@ -384,7 +384,7 @@ def doc_link(page=None, anchor='', text=N_('Help'), **kwargs):
     XXX: Target attribute is not XHTML compliant.
     """
     attrs = {
-        'href': 'http://mediadrop.net/docs/user/%s.html#%s' % (page, anchor),
+        'href': 'http://mediadrop.video/docs/user/%s.html#%s' % (page, anchor),
         'target': '_blank',
     }
     if kwargs:

--- a/mediadrop/lib/i18n.py
+++ b/mediadrop/lib/i18n.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/js_delivery.py
+++ b/mediadrop/lib/js_delivery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/paginate.py
+++ b/mediadrop/lib/paginate.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/players.py
+++ b/mediadrop/lib/players.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or
@@ -1092,7 +1092,7 @@ def embed_iframe(media, width=400, height=225, frameborder=0, **kwargs):
                   frameborder=frameborder, **kwargs)
     # some software is known not to work with self-closing iframe tags 
     # ('<iframe ... />'). Several WordPress instances are affected as well as
-    # TWiki http://mediadrop.net/community/topic/embed-iframe-closing-tag
+    # TWiki http://mediadrop.video/community/topic/embed-iframe-closing-tag
     tag.append('')
     return tag
 

--- a/mediadrop/lib/routing_helpers.py
+++ b/mediadrop/lib/routing_helpers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/services/__init__.py
+++ b/mediadrop/lib/services/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/services/facebook.py
+++ b/mediadrop/lib/services/facebook.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/services/tests/youtube_client_test.py
+++ b/mediadrop/lib/services/tests/youtube_client_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/services/youtube.py
+++ b/mediadrop/lib/services/youtube.py
@@ -1,5 +1,5 @@
 # -*- coding: UTF-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/storage/__init__.py
+++ b/mediadrop/lib/storage/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/storage/api.py
+++ b/mediadrop/lib/storage/api.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/storage/bliptv.py
+++ b/mediadrop/lib/storage/bliptv.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/storage/dailymotion.py
+++ b/mediadrop/lib/storage/dailymotion.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/storage/ftp.py
+++ b/mediadrop/lib/storage/ftp.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/storage/googlevideo.py
+++ b/mediadrop/lib/storage/googlevideo.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/storage/localfiles.py
+++ b/mediadrop/lib/storage/localfiles.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/storage/remoteurls.py
+++ b/mediadrop/lib/storage/remoteurls.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/storage/tests/youtube_storage_test.py
+++ b/mediadrop/lib/storage/tests/youtube_storage_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/storage/vimeo.py
+++ b/mediadrop/lib/storage/vimeo.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/storage/youtube.py
+++ b/mediadrop/lib/storage/youtube.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/templating.py
+++ b/mediadrop/lib/templating.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/test/__init__.py
+++ b/mediadrop/lib/test/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/test/controller_testcase.py
+++ b/mediadrop/lib/test/controller_testcase.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/test/db_testcase.py
+++ b/mediadrop/lib/test/db_testcase.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/test/request_mixin.py
+++ b/mediadrop/lib/test/request_mixin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/test/support.py
+++ b/mediadrop/lib/test/support.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/tests/css_delivery_test.py
+++ b/mediadrop/lib/tests/css_delivery_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/tests/current_url_test.py
+++ b/mediadrop/lib/tests/current_url_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/tests/helpers_test.py
+++ b/mediadrop/lib/tests/helpers_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/tests/human_readable_size_test.py
+++ b/mediadrop/lib/tests/human_readable_size_test.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2014 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is is dual licensed under the MIT license or

--- a/mediadrop/lib/tests/js_delivery_test.py
+++ b/mediadrop/lib/tests/js_delivery_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/tests/observable_test.py
+++ b/mediadrop/lib/tests/observable_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/tests/players_test.py
+++ b/mediadrop/lib/tests/players_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/tests/request_mixin_test.py
+++ b/mediadrop/lib/tests/request_mixin_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code in this file is dual licensed under the MIT license or

--- a/mediadrop/lib/tests/translator_test.py
+++ b/mediadrop/lib/tests/translator_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/tests/url_for_test.py
+++ b/mediadrop/lib/tests/url_for_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/tests/xhtml_normalization_test.py
+++ b/mediadrop/lib/tests/xhtml_normalization_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/thumbnails.py
+++ b/mediadrop/lib/thumbnails.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/uri.py
+++ b/mediadrop/lib/uri.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/util.py
+++ b/mediadrop/lib/util.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/lib/xhtml/__init__.py
+++ b/mediadrop/lib/xhtml/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/script.py.mako
+++ b/mediadrop/migrations/script.py.mako
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2014 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/util.py
+++ b/mediadrop/migrations/util.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/versions/000-50258ad7a96d-add-display-footer-setting.py
+++ b/mediadrop/migrations/versions/000-50258ad7a96d-add-display-footer-setting.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/versions/001-51c050c6bca0-add_player_appearance_settings.py
+++ b/mediadrop/migrations/versions/001-51c050c6bca0-add_player_appearance_settings.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/versions/002-432df7befe8d-add_facebook_comments_settings.py
+++ b/mediadrop/migrations/versions/002-432df7befe8d-add_facebook_comments_settings.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/versions/003-4d27ff5680e5-normalize_comment_approval_setting.py
+++ b/mediadrop/migrations/versions/003-4d27ff5680e5-normalize_comment_approval_setting.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/versions/004-280565a54124-add_custom_head_tags.py
+++ b/mediadrop/migrations/versions/004-280565a54124-add_custom_head_tags.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/versions/005-16ed4c91d1aa-add_anonymous_and_authenticated_groups.py
+++ b/mediadrop/migrations/versions/005-16ed4c91d1aa-add_anonymous_and_authenticated_groups.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/versions/006-30bb0d88d139-add_view_permission.py
+++ b/mediadrop/migrations/versions/006-30bb0d88d139-add_view_permission.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/versions/007-3b2f74a50399-add_upload_permissio.py
+++ b/mediadrop/migrations/versions/007-3b2f74a50399-add_upload_permissio.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/versions/008-4c9f4cfc6085-drop_sqlalchemy_migrate_table.py
+++ b/mediadrop/migrations/versions/008-4c9f4cfc6085-drop_sqlalchemy_migrate_table.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/versions/009-47f9265e77e5-mediadrop_comments_engine.py
+++ b/mediadrop/migrations/versions/009-47f9265e77e5-mediadrop_comments_engine.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/versions/010-e1488bb4dd-rename_mediacore_settings.py
+++ b/mediadrop/migrations/versions/010-e1488bb4dd-rename_mediacore_settings.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/migrations/versions/011-4979e106cad8-add_youtube_apikey.py
+++ b/mediadrop/migrations/versions/011-4979e106cad8-add_youtube_apikey.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/__init__.py
+++ b/mediadrop/model/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/auth.py
+++ b/mediadrop/model/auth.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/authors.py
+++ b/mediadrop/model/authors.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/categories.py
+++ b/mediadrop/model/categories.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/comments.py
+++ b/mediadrop/model/comments.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/media.py
+++ b/mediadrop/model/media.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/meta.py
+++ b/mediadrop/model/meta.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/players.py
+++ b/mediadrop/model/players.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/podcasts.py
+++ b/mediadrop/model/podcasts.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/settings.py
+++ b/mediadrop/model/settings.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/storage.py
+++ b/mediadrop/model/storage.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/tags.py
+++ b/mediadrop/model/tags.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/tests/category_example_test.py
+++ b/mediadrop/model/tests/category_example_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/tests/group_example_test.py
+++ b/mediadrop/model/tests/group_example_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/tests/media_example_test.py
+++ b/mediadrop/model/tests/media_example_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/tests/media_status_test.py
+++ b/mediadrop/model/tests/media_status_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/tests/media_test.py
+++ b/mediadrop/model/tests/media_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/tests/user_example_test.py
+++ b/mediadrop/model/tests/user_example_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/model/util.py
+++ b/mediadrop/model/util.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 

--- a/mediadrop/plugin/__init__.py
+++ b/mediadrop/plugin/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/plugin/abc.py
+++ b/mediadrop/plugin/abc.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/plugin/events.py
+++ b/mediadrop/plugin/events.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/plugin/manager.py
+++ b/mediadrop/plugin/manager.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/plugin/plugin.py
+++ b/mediadrop/plugin/plugin.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/plugin/tests/abstract_class_registration_test.py
+++ b/mediadrop/plugin/tests/abstract_class_registration_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/plugin/tests/events_test.py
+++ b/mediadrop/plugin/tests/events_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/plugin/tests/observes_test.py
+++ b/mediadrop/plugin/tests/observes_test.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/scripts/api.js
+++ b/mediadrop/public/admin/scripts/api.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/scripts/comments.js
+++ b/mediadrop/public/admin/scripts/comments.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/scripts/confirm.js
+++ b/mediadrop/public/admin/scripts/confirm.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/scripts/dropdown.js
+++ b/mediadrop/public/admin/scripts/dropdown.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/scripts/forms.js
+++ b/mediadrop/public/admin/scripts/forms.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/scripts/global.js
+++ b/mediadrop/public/admin/scripts/global.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/scripts/media.js
+++ b/mediadrop/public/admin/scripts/media.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/scripts/modals.js
+++ b/mediadrop/public/admin/scripts/modals.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/scripts/show-more.js
+++ b/mediadrop/public/admin/scripts/show-more.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/scripts/tablemgrs.js
+++ b/mediadrop/public/admin/scripts/tablemgrs.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/scripts/uploader.js
+++ b/mediadrop/public/admin/scripts/uploader.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/scripts/users.js
+++ b/mediadrop/public/admin/scripts/users.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/base.css
+++ b/mediadrop/public/admin/styles/base.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/categories.css
+++ b/mediadrop/public/admin/styles/categories.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/comments.css
+++ b/mediadrop/public/admin/styles/comments.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/datepicker.css
+++ b/mediadrop/public/admin/styles/datepicker.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/forms.css
+++ b/mediadrop/public/admin/styles/forms.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/groups.css
+++ b/mediadrop/public/admin/styles/groups.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/media.css
+++ b/mediadrop/public/admin/styles/media.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/players.css
+++ b/mediadrop/public/admin/styles/players.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/podcasts.css
+++ b/mediadrop/public/admin/styles/podcasts.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/settings.css
+++ b/mediadrop/public/admin/styles/settings.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/squeezebox.css
+++ b/mediadrop/public/admin/styles/squeezebox.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/storage.css
+++ b/mediadrop/public/admin/styles/storage.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/uploader.css
+++ b/mediadrop/public/admin/styles/uploader.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/admin/styles/users.css
+++ b/mediadrop/public/admin/styles/users.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/scripts/mcore/base.js
+++ b/mediadrop/public/scripts/mcore/base.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/comments.js
+++ b/mediadrop/public/scripts/mcore/comments.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/cooliris.js
+++ b/mediadrop/public/scripts/mcore/cooliris.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/excerpts.js
+++ b/mediadrop/public/scripts/mcore/excerpts.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/externs.js
+++ b/mediadrop/public/scripts/mcore/externs.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/fx.js
+++ b/mediadrop/public/scripts/mcore/fx.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/likes.js
+++ b/mediadrop/public/scripts/mcore/likes.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/net.js
+++ b/mediadrop/public/scripts/mcore/net.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/players/controller.js
+++ b/mediadrop/public/scripts/mcore/players/controller.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/players/flash.js
+++ b/mediadrop/public/scripts/mcore/players/flash.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/players/html5.js
+++ b/mediadrop/public/scripts/mcore/players/html5.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/players/iframe.js
+++ b/mediadrop/public/scripts/mcore/players/iframe.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/players/jwplayer_.js
+++ b/mediadrop/public/scripts/mcore/players/jwplayer_.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/players/multi.js
+++ b/mediadrop/public/scripts/mcore/players/multi.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/players/players.js
+++ b/mediadrop/public/scripts/mcore/players/players.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/players/rater.js
+++ b/mediadrop/public/scripts/mcore/players/rater.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/players/resizer.js
+++ b/mediadrop/public/scripts/mcore/players/resizer.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/players/sublime.js
+++ b/mediadrop/public/scripts/mcore/players/sublime.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/mcore/popups.js
+++ b/mediadrop/public/scripts/mcore/popups.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/scripts/uploader.js
+++ b/mediadrop/public/scripts/uploader.js
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under an MIT style license.

--- a/mediadrop/public/styles/base.css
+++ b/mediadrop/public/styles/base.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/styles/categories.css
+++ b/mediadrop/public/styles/categories.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/styles/comments.css
+++ b/mediadrop/public/styles/comments.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/styles/error.css
+++ b/mediadrop/public/styles/error.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/styles/login.css
+++ b/mediadrop/public/styles/login.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/styles/podcasts.css
+++ b/mediadrop/public/styles/podcasts.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/public/styles/upload.css
+++ b/mediadrop/public/styles/upload.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/box-form.html
+++ b/mediadrop/templates/admin/box-form.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/categories/edit.html
+++ b/mediadrop/templates/admin/categories/edit.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/categories/index.html
+++ b/mediadrop/templates/admin/categories/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/categories/row-form.html
+++ b/mediadrop/templates/admin/categories/row-form.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/categories/selection_list.html
+++ b/mediadrop/templates/admin/categories/selection_list.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/comments/_comment-table.html
+++ b/mediadrop/templates/admin/comments/_comment-table.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/comments/edit.html
+++ b/mediadrop/templates/admin/comments/edit.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/comments/index-table.html
+++ b/mediadrop/templates/admin/comments/index-table.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/comments/index.html
+++ b/mediadrop/templates/admin/comments/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/groups/edit.html
+++ b/mediadrop/templates/admin/groups/edit.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/groups/index.html
+++ b/mediadrop/templates/admin/groups/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/helpers.html
+++ b/mediadrop/templates/admin/helpers.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/index.html
+++ b/mediadrop/templates/admin/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/master.html
+++ b/mediadrop/templates/admin/master.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/media/_media-table.html
+++ b/mediadrop/templates/admin/media/_media-table.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/media/dash-table.html
+++ b/mediadrop/templates/admin/media/dash-table.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/media/edit.html
+++ b/mediadrop/templates/admin/media/edit.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/media/file-add-form.html
+++ b/mediadrop/templates/admin/media/file-add-form.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/media/file-edit-form.html
+++ b/mediadrop/templates/admin/media/file-edit-form.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/media/file-form.html
+++ b/mediadrop/templates/admin/media/file-form.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/media/index-table.html
+++ b/mediadrop/templates/admin/media/index-table.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/media/index.html
+++ b/mediadrop/templates/admin/media/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/media/update-status-form.html
+++ b/mediadrop/templates/admin/media/update-status-form.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/players/edit.html
+++ b/mediadrop/templates/admin/players/edit.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/players/index.html
+++ b/mediadrop/templates/admin/players/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/podcasts/_podcast-table.html
+++ b/mediadrop/templates/admin/podcasts/_podcast-table.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/podcasts/edit.html
+++ b/mediadrop/templates/admin/podcasts/edit.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/podcasts/feed_fieldset.html
+++ b/mediadrop/templates/admin/podcasts/feed_fieldset.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/podcasts/index-table.html
+++ b/mediadrop/templates/admin/podcasts/index-table.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/podcasts/index.html
+++ b/mediadrop/templates/admin/podcasts/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/search-form.html
+++ b/mediadrop/templates/admin/search-form.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/advertising.html
+++ b/mediadrop/templates/admin/settings/advertising.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/analytics.html
+++ b/mediadrop/templates/admin/settings/analytics.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/api.html
+++ b/mediadrop/templates/admin/settings/api.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/appearance.html
+++ b/mediadrop/templates/admin/settings/appearance.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/appearance_input_field.html
+++ b/mediadrop/templates/admin/settings/appearance_input_field.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/appearance_list_fieldset.html
+++ b/mediadrop/templates/admin/settings/appearance_list_fieldset.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/comments.html
+++ b/mediadrop/templates/admin/settings/comments.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/general.html
+++ b/mediadrop/templates/admin/settings/general.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/googleapi.html
+++ b/mediadrop/templates/admin/settings/googleapi.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/master.html
+++ b/mediadrop/templates/admin/settings/master.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/notifications.html
+++ b/mediadrop/templates/admin/settings/notifications.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/popularity.html
+++ b/mediadrop/templates/admin/settings/popularity.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/sitemaps.html
+++ b/mediadrop/templates/admin/settings/sitemaps.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/settings/upload.html
+++ b/mediadrop/templates/admin/settings/upload.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/storage/edit.html
+++ b/mediadrop/templates/admin/storage/edit.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/storage/index.html
+++ b/mediadrop/templates/admin/storage/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/tags/edit.html
+++ b/mediadrop/templates/admin/tags/edit.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/tags/index.html
+++ b/mediadrop/templates/admin/tags/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/tags/row-form.html
+++ b/mediadrop/templates/admin/tags/row-form.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/tags_and_categories_form.html
+++ b/mediadrop/templates/admin/tags_and_categories_form.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/thumb-form.html
+++ b/mediadrop/templates/admin/thumb-form.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/users/edit.html
+++ b/mediadrop/templates/admin/users/edit.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/admin/users/index.html
+++ b/mediadrop/templates/admin/users/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/appearance.css
+++ b/mediadrop/templates/appearance.css
@@ -1,5 +1,5 @@
 /**
- * This file is a part of MediaDrop (http://www.mediadrop.net),
+ * This file is a part of MediaDrop (http://www.mediadrop.video),
  * Copyright 2009-2014 MediaDrop contributors
  * For the exact contribution history, see the git revision log.
  * The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/categories/index.html
+++ b/mediadrop/templates/categories/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/categories/layout.html
+++ b/mediadrop/templates/categories/layout.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/categories/more.html
+++ b/mediadrop/templates/categories/more.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/comments/_list.html
+++ b/mediadrop/templates/comments/_list.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/comments/facebook.html
+++ b/mediadrop/templates/comments/facebook.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/error.html
+++ b/mediadrop/templates/error.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/forms/box_form.html
+++ b/mediadrop/templates/forms/box_form.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/forms/button.html
+++ b/mediadrop/templates/forms/button.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/forms/fieldset.html
+++ b/mediadrop/templates/forms/fieldset.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/helpers.html
+++ b/mediadrop/templates/helpers.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/layout.html
+++ b/mediadrop/templates/layout.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or
@@ -36,7 +36,7 @@ See LICENSE.txt in the main project directory, for more information.
 			</ul>
 		</div>
 		<div py:if="settings['appearance_display_mediadrop_credits']" id="mcore-credits" class="f-rgt">
-			<a href="http://mediadrop.net" class="mcore-foot-link underline-hover" i18n:msg=""><strong>MediaDrop</strong> <em>video platform</em></a>
+			<a href="http://mediadrop.video" class="mcore-foot-link underline-hover" i18n:msg=""><strong>MediaDrop</strong> <em>video platform</em></a>
 		</div>
 	</div>
 

--- a/mediadrop/templates/login.html
+++ b/mediadrop/templates/login.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/master.html
+++ b/mediadrop/templates/master.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/media/explore.html
+++ b/mediadrop/templates/media/explore.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/media/index.html
+++ b/mediadrop/templates/media/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/media/tags.html
+++ b/mediadrop/templates/media/tags.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/media/view.html
+++ b/mediadrop/templates/media/view.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/players/html5_or_flash.html
+++ b/mediadrop/templates/players/html5_or_flash.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/players/iframe.html
+++ b/mediadrop/templates/players/iframe.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/podcasts/feed.xml
+++ b/mediadrop/templates/podcasts/feed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2014 MediaDrop contributors.
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/podcasts/index.html
+++ b/mediadrop/templates/podcasts/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/podcasts/view.html
+++ b/mediadrop/templates/podcasts/view.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/sitemaps/google.xml
+++ b/mediadrop/templates/sitemaps/google.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2014 MediaDrop contributors.
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/sitemaps/mrss.xml
+++ b/mediadrop/templates/sitemaps/mrss.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2014 MediaDrop contributors.
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/upload/failure.html
+++ b/mediadrop/templates/upload/failure.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/upload/form.html
+++ b/mediadrop/templates/upload/form.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/upload/index.html
+++ b/mediadrop/templates/upload/index.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/templates/upload/success.html
+++ b/mediadrop/templates/upload/success.html
@@ -1,5 +1,5 @@
 <!--!
-This file is a part of MediaDrop (http://www.mediadrop.net),
+This file is a part of MediaDrop (http://www.mediadrop.video),
 Copyright 2009-2015 MediaDrop contributors
 For the exact contribution history, see the git revision log.
 The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/tests/__init__.py
+++ b/mediadrop/tests/__init__.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/tests/functional/test_admin_media.py
+++ b/mediadrop/tests/functional/test_admin_media.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/tests/functional/test_login.py
+++ b/mediadrop/tests/functional/test_login.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/validation/limit_feed_items_validator.py
+++ b/mediadrop/validation/limit_feed_items_validator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/validation/tests/limit_feed_items_validator_test.py
+++ b/mediadrop/validation/tests/limit_feed_items_validator_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/validation/tests/uri_validator_test.py
+++ b/mediadrop/validation/tests/uri_validator_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/validation/uri_validator.py
+++ b/mediadrop/validation/uri_validator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or

--- a/mediadrop/websetup.py
+++ b/mediadrop/websetup.py
@@ -1,4 +1,4 @@
-# This file is a part of MediaDrop (http://www.mediadrop.net),
+# This file is a part of MediaDrop (http://www.mediadrop.video),
 # Copyright 2009-2015 MediaDrop contributors
 # For the exact contribution history, see the git revision log.
 # The source code contained in this file is licensed under the GPLv3 or
@@ -327,7 +327,7 @@ def add_default_data():
         u'This sceencast explains the publish status feature in MediaDrop.\nInitially all videos uploaded through the front-end or admin panel are placed under \"awaiting review\" status. Once the administrator hits the \"review complete\" button, they can upload media. Videos can be added in any format, however, they can only be published if they are in a web-ready format such as FLV, M4V, MP3, or MP4. Alternatively, if they are published through Youtube or Vimeo the encoding step is skipped\nOnce uploaded and encoded the administrator can then publish the video.',
         datetime.datetime(2010, 5, 13, 2, 29, 40),
         218,
-        u'http://static.mediadrop.net/files/videos/tutorial-workflow-in-mediadrop.mp4',
+        u'http://static.mediadrop.video/files/videos/tutorial-workflow-in-mediadrop.mp4',
         u'video',
         u'mp4',
         ),
@@ -337,7 +337,7 @@ def add_default_data():
         u'This describes the process an administrator goes through in creating a podcast in MediaDrop. An administrator can enter information that will automatically generate the iTunes/RSS feed information. Any episodes published to a podcast will automatically publish to iTunes/RSS.',
         datetime.datetime(2010, 5, 13, 2, 33, 44),
         100,
-        u'http://static.mediadrop.net/files/videos/tutorial-create-podcast-in-mediadrop.mp4',
+        u'http://static.mediadrop.video/files/videos/tutorial-create-podcast-in-mediadrop.mp4',
         u'video',
         u'mp4',
         ),
@@ -347,14 +347,14 @@ def add_default_data():
         u'This screencast shows how video or audio can be added in MediaDrop.\nMediaDrop supports a wide range of formats including (but not limited to): YouTube, Vimeo, Amazon S3, Bits on the Run, BrightCove, Kaltura, and either your own server or someone else\'s.\nVideos can be uploaded in any format, but can only be published in web-ready formats such as FLV, MP3, M4V, MP4 etc.',
         datetime.datetime(2010, 5, 13, 02, 37, 36),
         169,
-        u'http://static.mediadrop.net/files/videos/tutorial-add-video-in-mediadrop.mp4',
+        u'http://static.mediadrop.video/files/videos/tutorial-add-video-in-mediadrop.mp4',
         u'video',
         u'mp4',
         ),
     ]
 
     name = u'MediaDrop Team'
-    email = u'info@mediadrop.net'
+    email = u'info@mediadrop.video'
     for slug, title, desc, desc_plain, publish_on, duration, url, type_, container in instructional_media:
         media = Media()
         media.author = Author(name, email)

--- a/requirements.py26.txt
+++ b/requirements.py26.txt
@@ -1,2 +1,2 @@
---index-url=http://static.mediadrop.net/dependencies/dev/
+--index-url=http://static.mediadrop.video/dependencies/dev/
 importlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
---index-url=http://static.mediadrop.net/dependencies/dev/
+--index-url=http://static.mediadrop.video/dependencies/dev/
 iso8601
 ddt
 formencode >= 1.2.4 # (version required by Pylons 1.0)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,8 +4,8 @@
 
 [easy_install]
 # Look to our server for a known-good set of dependencies
-find_links = http://static.mediadrop.net/dependencies/dev/
-allow_hosts = static.mediadrop.net
+find_links = http://static.mediadrop.video/dependencies/dev/
+allow_hosts = static.mediadrop.video
 
 [nosetests]
 nologcapture = True

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ setup(
     version=VERSION,
     description='A audio, video and podcast publication platform.',
     author='MediaDrop contributors.',
-    author_email='info@mediadrop.net',
-    url='http://mediadrop.net',
+    author_email='info@mediadrop.video',
+    url='http://mediadrop.video',
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: GNU General Public License (GPL)',


### PR DESCRIPTION
As stated in Issue #228 the domain changed from mediadrop.net to mediadrop.video.